### PR TITLE
Update gdo.json to ore_dict

### DIFF
--- a/src/main/resources/assets/jsg/recipes/item/tool/gdo.json
+++ b/src/main/resources/assets/jsg/recipes/item/tool/gdo.json
@@ -12,19 +12,23 @@
 		},
 
 		"G": {
-			"item": "minecraft:glass_pane"
+			"type": "forge:ore_dict",
+      			"ore": "paneGlass"
 		},
 
 		"N": {
-			"item": "minecraft:iron_ingot"
+			"type": "forge:ore_dict",
+      			"ore": "ingotIron"
 		},
 
 		"I": {
-			"item": "minecraft:redstone"
+			"type": "forge:ore_dict",
+      			"ore": "dustRedstone"
 		},
 
 		"Y": {
-			"item": "jsg:gear_titanium"
+			"type": "forge:ore_dict",
+      			"ore": "gearTitanium"
 		}
 	},
 


### PR DESCRIPTION
I got an Issue with the recipe of the GDO while Advanced Rocketry installed. The JSG Titanium Gear was not craftable.
To fix this issue i changed the recipe to ore_dict.