### PR TITLE
Made PEG and UNI gates accept Point of Origin

### DIFF
--- a/src/main/java/tauri/dev/jsg/stargate/network/SymbolPegasusEnum.java
+++ b/src/main/java/tauri/dev/jsg/stargate/network/SymbolPegasusEnum.java
@@ -181,6 +181,7 @@ public enum SymbolPegasusEnum implements SymbolInterface {
             ID_MAP.put(symbol.id, symbol);
             ENGLISH_NAME_MAP.put(symbol.englishName.toLowerCase(), symbol);
         }
+        ENGLISH_NAME_MAP.put("point of origin", SUBIDO);
     }
 
     public static SymbolPegasusEnum valueOf(int id) {

--- a/src/main/java/tauri/dev/jsg/stargate/network/SymbolUniverseEnum.java
+++ b/src/main/java/tauri/dev/jsg/stargate/network/SymbolUniverseEnum.java
@@ -223,6 +223,7 @@ public enum SymbolUniverseEnum implements SymbolInterface {
             ID_MAP.put(symbol.id, symbol);
             ENGLISH_NAME_MAP.put(symbol.englishName.toLowerCase(), symbol);
         }
+        ENGLISH_NAME_MAP.put("point of origin", G17);
     }
 
     public static SymbolUniverseEnum valueOf(int id) {


### PR DESCRIPTION
Made Pegasus and Universe gates accept `Point of Origin` (case insensitive) when being dialed to make dialing with computers more consistent between the 3 gate types to eliminate some confusion for new users